### PR TITLE
Changed anchor for target frame

### DIFF
--- a/FFXIV_UI/General/FFXIV_UI_Menu.lua
+++ b/FFXIV_UI/General/FFXIV_UI_Menu.lua
@@ -10,11 +10,11 @@ local anchorConfigs = {
     { key = "PlayerHP",      label = "Player Health",      w = 240, h = 86,  scale = 1.0, pos = {"BOTTOM", -140, 55} },
     { key = "PlayerPower",   label = "Player Power",       w = 240, h = 86,  scale = 1.0, pos = {"BOTTOM", 100, 55} },
     { key = "PlayerPowerSec",label = "Secondary Power",    w = 240, h = 86,  scale = 1.0, pos = {"BOTTOM", 340, 55} },
-    { key = "TargetAuras",   label = "Target Buffs",       w = 850, h = 45,  scale = 1.0, pos = {"CENTER", 90, 455} },
-    { key = "TargetDebuffs", label = "Target Debuffs",     w = 850, h = 45,  scale = 1.0, pos = {"CENTER", 90, 410} },
-    { key = "TargetCast",    label = "Target Castbar",     w = 350, h = 30,  scale = 1.0, pos = {"CENTER", 180, 525} },
-    { key = "TargetHP",      label = "Target Health",      w = 670, h = 50,  scale = 1.0, pos = {"CENTER", 0, 500} },
-    { key = "TargetOfTarget",label = "Target of Target",   w = 340, h = 50,  scale = 1.0, pos = {"CENTER", 505, 500} },
+    { key = "TargetAuras",   label = "Target Buffs",       w = 850, h = 45,  scale = 1.0, pos = {"TOP", 90, -70} },
+    { key = "TargetDebuffs", label = "Target Debuffs",     w = 850, h = 45,  scale = 1.0, pos = {"TOP", 90, -115} },
+    { key = "TargetCast",    label = "Target Castbar",     w = 350, h = 30,  scale = 1.0, pos = {"TOP", 180, 0} },
+    { key = "TargetHP",      label = "Target Health",      w = 670, h = 50,  scale = 1.0, pos = {"TOP", 0, -25} },
+    { key = "TargetOfTarget",label = "Target of Target",   w = 340, h = 50,  scale = 1.0, pos = {"TOP", 505, -25} },
 }
 
 local visualBoxes = {}


### PR DESCRIPTION
On screens with atypical resolutions, the target frame can be off screen because it's anchored to the center. Instead, I updated that to anchor all the target UI to the top of the screen.

I maintained the offsets that were in there originally, though I'm not sure exactly how far from the top the UI was originally, so those new values could definitely be adjusted more if desired.