### PR TITLE
Updated strata of HP click

### DIFF
--- a/PlayerFrames/PlayerFrame_HP.lua
+++ b/PlayerFrames/PlayerFrame_HP.lua
@@ -76,7 +76,7 @@ local CLICK_RECT_WIDTH  = s(240)
 local CLICK_RECT_HEIGHT = s(48)
 local clickFrame = CreateFrame("Button", nil, outlineFrame, "SecureUnitButtonTemplate")
 
-clickFrame:SetFrameStrata("HIGH")
+clickFrame:SetFrameStrata("MEDIUM")
 clickFrame:SetFrameLevel(outlineFrame:GetFrameLevel() + 10)
 clickFrame:SetSize(CLICK_RECT_WIDTH, CLICK_RECT_HEIGHT)
 clickFrame:SetPoint("CENTER", outlineFrame, "CENTER", 0, s(-10))


### PR DESCRIPTION
The player HP click strata was set to high, which meant that it was taking priority over UI elements. I moved my HP  bar a bit up, which meant that I couldn't click the "apply" button for my talents, since it was in the same spot as my HP bar.